### PR TITLE
Fix README heading line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ips2subnets
 Perl script to help generate a shorter list from an IPv4 list, possibly using subnets.
-
 # Example
 ```
 cat <<<EOF | ./ips2subnets


### PR DESCRIPTION
## Summary
- combine README lines to keep the description on one line

## Testing
- `perl -c ips2subnets`

------
https://chatgpt.com/codex/tasks/task_e_68760bd9ffc0832798473fead0aab61b